### PR TITLE
2024 code maintaining

### DIFF
--- a/ESP32_Oscilloscope/ESP32_Oscilloscope.ino
+++ b/ESP32_Oscilloscope/ESP32_Oscilloscope.ino
@@ -21,7 +21,7 @@
 #define BUFF_SIZE 50000
 #define B_MULT BUFF_SIZE/NUM_SAMPLES
 #define BUTTON_Ok        32
-#define BUTTON_Plus        15
+#define BUTTON_Plus        25
 #define BUTTON_Minus        35
 #define BUTTON_Back        34
 
@@ -159,12 +159,13 @@ void core0_task( void * pvParameters ) {
     if (new_data || menu_action) {
       new_data = false;
       menu_action = false;
-
       updating_screen = true;
       update_screen(i2s_buff, RATE);
       updating_screen = false;
       vTaskDelay(pdMS_TO_TICKS(10));
+#ifdef DEBUG_SERIAL
       Serial.println("CORE0");
+#endif
     }
 
     vTaskDelay(pdMS_TO_TICKS(10));
@@ -181,22 +182,9 @@ void core1_task( void * pvParameters ) {
       while (updating_screen) {
         vTaskDelay(pdMS_TO_TICKS(1));
       }
-      if (!stop) {
-        if (stop_change) {
-          i2s_adc_enable(I2S_NUM_0);
-          stop_change = false;
-        }
-        ADC_Sampling(i2s_buff);
-        new_data = true;
-      }
-      else {
-        if (!stop_change) {
-          i2s_adc_disable(I2S_NUM_0);
-          i2s_zero_dma_buffer(I2S_NUM_0);
-          stop_change = true;
-        }
-      }
+#ifdef DEBUG_SERIAL
       Serial.println("CORE1");
+#endif
       vTaskDelay(pdMS_TO_TICKS(300));
     }
     else {
@@ -235,7 +223,9 @@ void core1_task( void * pvParameters ) {
 
           single_trigger = false;
           new_data = true;
+#ifdef DEBUG_SERIAL
           Serial.println("Single GOT");
+#endif
           //return to normal execution in stop mode
         }
 
@@ -247,4 +237,20 @@ void core1_task( void * pvParameters ) {
   }
 }
 
-void loop() {}
+void loop() {
+  if (!stop) {
+    if (stop_change) {
+      i2s_adc_enable(I2S_NUM_0);
+      stop_change = false;
+    }
+    ADC_Sampling(i2s_buff);
+    new_data = true;
+  }
+  else {
+    if (!stop_change) {
+      i2s_adc_disable(I2S_NUM_0);
+      i2s_zero_dma_buffer(I2S_NUM_0);
+      stop_change = true;
+    }
+  }
+}

--- a/ESP32_Oscilloscope/debug_routines.ino
+++ b/ESP32_Oscilloscope/debug_routines.ino
@@ -1,6 +1,6 @@
-#ifdef DEBUG_BUF
+#ifdef DEBUG_BUFF
 void debug_buffer() {
-  ADC_Sampling();
+  ADC_Sampling(i2s_buff);
   i2s_adc_disable(I2S_NUM_0);
   delay(1000);
   for (uint32_t i = 0; i < B_MULT * NUM_SAMPLES; i++) {

--- a/ESP32_Oscilloscope/i2s.ino
+++ b/ESP32_Oscilloscope/i2s.ino
@@ -14,8 +14,8 @@ void configure_i2s(int rate) {
     .dma_buf_len = NUM_SAMPLES,                                                   // number of samples
     .use_apll = 0,                                                                // no Audio PLL
   };
-  adc1_config_channel_atten(ADC_CHANNEL, ADC_ATTEN_11db);
-  adc1_config_width(ADC_WIDTH_12Bit);
+  adc1_config_channel_atten(ADC_CHANNEL, ADC_ATTEN_DB_11);
+  adc1_config_width(ADC_WIDTH_MAX);
   i2s_driver_install(I2S_NUM_0, &i2s_config, 0, NULL);
 
   i2s_set_adc_mode(ADC_UNIT_1, ADC_CHANNEL);
@@ -24,9 +24,11 @@ void configure_i2s(int rate) {
 }
 
 void ADC_Sampling(uint16_t *i2s_buff){
+  size_t bytes_read = sizeof(uint16_t);
   for (int i = 0; i < B_MULT; i++) {
-    //TODO i2s_read_bytes is deprecated, replace with new function
-    i2s_read_bytes(I2S_NUM_0, (char*)&i2s_buff[i * NUM_SAMPLES],  NUM_SAMPLES * sizeof(uint16_t), portMAX_DELAY);    
+    i2s_read(I2S_NUM_0, (char*)&i2s_buff[i * NUM_SAMPLES],  NUM_SAMPLES * sizeof(uint16_t), &bytes_read, portMAX_DELAY);    
+    for(size_t ix = 0; ix < bytes_read/2; ix++) 
+      i2s_buff[(i * NUM_SAMPLES) + ix] &= 0x0FFF; // 16bit to 12bit conversion 
   }
 }
 

--- a/ESP32_Oscilloscope/options_handler.ino
+++ b/ESP32_Oscilloscope/options_handler.ino
@@ -171,8 +171,10 @@ void button() {
 
           case Stop:
             stop = !stop;
-            //Serial.print("Stop : ");
-            //Serial.println(stop);
+#ifdef DEBUG_SERIAL
+            Serial.print("Stop : ");
+            Serial.println(stop);
+#endif
             set_value = false;
             break;
 

--- a/ESP32_Oscilloscope/screen.ino
+++ b/ESP32_Oscilloscope/screen.ino
@@ -19,7 +19,7 @@ float to_scale(float reading) {
                (
                  (
                    (
-                     (float)((reading - 20480.0) / 4095.0)
+                     (float)((reading/* - 20480.0*/) / 4095.0)
                      + (offset / 3.3)
                    )
                    * 3300 /
@@ -143,7 +143,6 @@ void draw_sprite(float freq,
       if (v_div <= 0)
         v_div = 550;
     }
-
     //only draw digital data if a trigger was in the data
     if (!(digital_wave_option == 2 && trigger == 0))
       draw_channel1(trigger, 0, i2s_buff, sample_rate);
@@ -236,6 +235,7 @@ void draw_channel1(uint32_t trigger0, uint32_t trigger1, uint16_t *i2s_buff, flo
   filter._value = i2s_buff[trigger0];
   float data_per_pixel = (s_div / 40.0) / (sample_rate / 1000);
 
+
   //  uint32_t cursor = (trigger1-trigger0)/data_per_pixel;
   //  spr.drawLine(cursor, 0, cursor, 135, TFT_RED);
 
@@ -268,6 +268,7 @@ void draw_channel1(uint32_t trigger0, uint32_t trigger1, uint16_t *i2s_buff, flo
           n_data = to_scale(i2s_buff[index]);
 
         spr.drawLine(i - 1, o_data, i, n_data, TFT_BLUE);
+
         o_data = n_data;
       }
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,17 @@ The Oscilloscope is a must-have test instrument for any electronics engineer. It
 <br>
 [Note: As this projects are very simple we are only providing the code, schemaitic, and a few essential images if you want to get the images or code explanations do check out the Circuit Digest website.
 <br>
-# HOW TO USE
-1- The `./ESP32_Oscilloscope` folder needs to go in your Arduio IDE sketches folder.
-2- You need to extract `.\ESP32_Oscilloscope\TFT_eSPI.zip` to the libraries folder for Arduino IDE
-3- Change configurations if needed
-If you want to change the pins for the SPI device (screen) or it's resolution, you need to edit `User_config.h` in the `TFT_eSPI` library folder
-If you want to change the pins for the buttons, it is in ESP32_Oscilloscope.ino
 <br>
+
+<h1> HOW TO USE </h1>
+<br>
+<br>
+1- The  ./ESP32_Oscilloscope folder needs to go in your Arduio IDE sketches folder.
+<br>
+2- You need to extract .\ESP32_Oscilloscope\TFT_eSPI.zip to the libraries folder for Arduino IDE
+<br>
+3- Change configurations if needed
+<br>
+If you want to change the pins for the SPI device (screen) or it's resolution, you need to edit User_config.h in the TFT_eSPI library folder
+<br>
+If you want to change the pins for the buttons, it is in ESP32_Oscilloscope.ino

--- a/README.md
+++ b/README.md
@@ -20,4 +20,10 @@ The Oscilloscope is a must-have test instrument for any electronics engineer. It
 <br>
 [Note: As this projects are very simple we are only providing the code, schemaitic, and a few essential images if you want to get the images or code explanations do check out the Circuit Digest website.
 <br>
+# HOW TO USE
+1- The `./ESP32_Oscilloscope` folder needs to go in your Arduio IDE sketches folder.
+2- You need to extract `.\ESP32_Oscilloscope\TFT_eSPI.zip` to the libraries folder for Arduino IDE
+3- Change configurations if needed
+If you want to change the pins for the SPI device (screen) or it's resolution, you need to edit `User_config.h` in the `TFT_eSPI` library folder
+If you want to change the pins for the buttons, it is in ESP32_Oscilloscope.ino
 <br>


### PR DESCRIPTION
# LIST OF ISSUES SOLVED
1- fixed issue #3 by replacing `i2s_read_bytes` with `i2s_read`
2- fixed core compiling issue by adding `#include "hal/gpio_ll.h"` to `TFT_eSPI_ESP32.h` in `TFT_eSPI\Processors`
3- fixed `to_scale` function, it had a random -20000 that botched everything
4- changed a few values that changed names
5- moved oscilloscope stop routines to `loop` function else it would crash because the wrong thread was calling `i2s_adc_disable`